### PR TITLE
update lint exclude command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Unlicense",
   "commonpkgShare": {
     "scripts": {
-      "lint": "tslint '**/*.t{s,sx}' -e '**/node_modules/**' --fix --project ./tsconfig.json --type-check",
+      "lint": "tslint '**/*.t{s,sx}' --e='**/node_modules/**' --fix --project ./tsconfig.json --type-check",
       "precommit": "lint-staged"
     },
     "devDependencies": {


### PR DESCRIPTION
The previous version of the exclude command didn't actually exclude `node_modules` and it was breaking our build. 
https://github.com/hollowverse/hollowverse/pull/96/