### PR TITLE
Script to validate file names

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "tslint-react": "^3.0.0"
   },
   "dependencies": {
+    "@types/node": "^8.0.24",
     "minimatch": "^3.0.4",
     "shelljs": "^0.7.8"
   }

--- a/package.json
+++ b/package.json
@@ -12,14 +12,18 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0",
+    "stylelint": "^7.12.0",
+    "stylelint-config-standard": "^16.0.0",
+    "stylelint-no-unsupported-browser-features": "^1.0.0",
     "tslint": "^5.5.0",
     "tslint-config-prettier": "^1.1.0",
     "tslint-eslint-rules": "^4.1.1",
     "tslint-loader": "^3.5.3",
     "tslint-microsoft-contrib": "^5.0.1",
-    "tslint-react": "^3.0.0",
-    "stylelint": "^7.12.0",
-    "stylelint-config-standard": "^16.0.0",
-    "stylelint-no-unsupported-browser-features": "^1.0.0"
+    "tslint-react": "^3.0.0"
+  },
+  "dependencies": {
+    "minimatch": "^3.0.4",
+    "shelljs": "^0.7.8"
   }
 }

--- a/validateFileNames.js
+++ b/validateFileNames.js
@@ -1,4 +1,5 @@
 const shelljs = require('shelljs');
+const minimatch = require('minimatch');
 
 // Regex that defines our file and directory naming convention
 const camelCasedFileNameRegex = /^[.]?([a-z])+([0-9]|[a-zA-Z]|[.])*$/;
@@ -8,8 +9,8 @@ const ignoredFilesAndDirectories = [
   'README.md',
   'Dockerfile',
   'LICENSE.md',
-  'customTypings',
-  'typings',
+  'customTypings/*',
+  'typings/*',
 ];
 
 // Get the list of files that we're interested in validating
@@ -49,7 +50,7 @@ files.forEach(file => {
 if (filesInViolation.length > 0) {
   // Yes, inform the user and exit with 1
   console.log(
-    `\n${underline('The file names below need to be camelCase:')}\n`,
+    `\n${underline('The file names below need to be camelCase:')}\n`
   );
 
   filesInViolation.forEach(file => {
@@ -77,13 +78,8 @@ function isCamelCase(filePathComponent) {
   return camelCasedFileNameRegex.test(filePathComponent);
 }
 function isIgnored(filePath) {
-  const pathComponents = filePath.split('/');
-
-  // Check if there is an intersection between ignoredFilesAndDirectories and pathComponents
   return ignoredFilesAndDirectories.some(ignoredFileOrDirectory => {
-    return pathComponents.some(pathComponent => {
-      return pathComponent === ignoredFileOrDirectory;
-    });
+    return minimatch(filePath, ignoredFileOrDirectory, {matchBase: true})
   });
 }
 function red(text) {

--- a/validateFileNames.js
+++ b/validateFileNames.js
@@ -49,7 +49,7 @@ files.forEach(file => {
 if (filesInViolation.length > 0) {
   // Yes, inform the user and exit with 1
   console.log(
-    `\n${underscore('The file names below need to be camelCase:')}\n`,
+    `\n${underline('The file names below need to be camelCase:')}\n`,
   );
 
   filesInViolation.forEach(file => {
@@ -69,7 +69,7 @@ function getFiles() {
   return files.split('\n').filter(file => {
     // remove empty strings from the array and remove files in ignored paths
     return (
-      file.length !== 0 && !isIgnored(file) 
+      file.length !== 0 && !isIgnored(file)
     );
   });
 }
@@ -89,6 +89,6 @@ function isIgnored(filePath) {
 function red(text) {
   return `\x1b[31m${text}\x1b[0m`;
 }
-function underscore(text) {
+function underline(text) {
   return `\x1b[4m${text}\x1b[0m`;
 }

--- a/validateFileNames.js
+++ b/validateFileNames.js
@@ -1,5 +1,6 @@
 const shelljs = require('shelljs');
 const minimatch = require('minimatch');
+const path = require('path')
 
 // Regex that defines our file and directory naming convention
 const camelCasedFileNameRegex = /^[.]?([a-z])+([0-9]|[a-zA-Z]|[.])*$/;
@@ -22,7 +23,7 @@ const filesInViolation = [];
 // Now let's go through the files to see if they violate the naming convention
 files.forEach(file => {
   // Split the path of the file to get the path components
-  const pathComponents = file.split('/');
+  const pathComponents = file.split(path.sep);
 
   // Let's start by assuming the file path has no invalid components
   let fileIsValid = true;
@@ -40,7 +41,7 @@ files.forEach(file => {
 
   // If we encountered any invalid components for this file, we'll remember the file.
   if (!fileIsValid) {
-    filesInViolation.push(processedPathComponents.join('/'));
+    filesInViolation.push(processedPathComponents.join(path.sep));
   }
 });
 

--- a/validateFileNames.js
+++ b/validateFileNames.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const shelljs = require('shelljs');
 const minimatch = require('minimatch');
 const path = require('path');

--- a/validateFileNames.js
+++ b/validateFileNames.js
@@ -67,8 +67,9 @@ function getFiles() {
   const files = shelljs.exec('git ls-files', { silent: true });
 
   return files.split('\n').filter(file => {
+    // remove empty strings from the array and remove files in ignored paths
     return (
-      file.length !== 0 && !isIgnored(file) // remove empty strings from the array // remove files in ignored paths
+      file.length !== 0 && !isIgnored(file) 
     );
   });
 }

--- a/validateFileNames.js
+++ b/validateFileNames.js
@@ -1,13 +1,12 @@
 const shelljs = require('shelljs');
 const minimatch = require('minimatch');
-const path = require('path')
-const fs = require('fs')
+const path = require('path');
 
 // Regex that defines our file and directory naming convention
 const camelCasedFileNameRegex = /^[.]?([a-z])+([0-9]|[a-zA-Z]|[.])*$/;
 
 // Files and directories that are exempt from the naming convention
-let ignoredFilesAndDirectories = []
+let ignoredFilesAndDirectories = [];
 
 try {
   ignoredFilesAndDirectories = require(`${process.cwd()}/validateFileNames.js`);
@@ -57,9 +56,7 @@ files.forEach(file => {
 // So, did we have any files in violation?
 if (filesInViolation.length > 0) {
   // Yes, inform the user and exit with 1
-  console.log(
-    `\n${underline('The file names below need to be camelCase:')}\n`
-  );
+  console.log(`\n${underline('The file names below need to be camelCase:')}\n`);
 
   filesInViolation.forEach(file => {
     console.log(`• ${file}`);
@@ -77,9 +74,7 @@ function getFiles() {
 
   return files.split('\n').filter(file => {
     // remove empty strings from the array and remove files in ignored paths
-    return (
-      file.length !== 0 && !isIgnored(file)
-    );
+    return file.length !== 0 && !isIgnored(file);
   });
 }
 function isCamelCase(filePathComponent) {
@@ -87,7 +82,7 @@ function isCamelCase(filePathComponent) {
 }
 function isIgnored(filePath) {
   return ignoredFilesAndDirectories.some(ignoredFileOrDirectory => {
-    return minimatch(filePath, ignoredFileOrDirectory, {matchBase: true})
+    return minimatch(filePath, ignoredFileOrDirectory, { matchBase: true });
   });
 }
 function red(text) {

--- a/validateFileNames.js
+++ b/validateFileNames.js
@@ -1,0 +1,93 @@
+const shelljs = require('shelljs');
+
+// Regex that defines our file and directory naming convention
+const camelCasedFileNameRegex = /^[.]?([a-z])+([0-9]|[a-zA-Z]|[.])*$/;
+
+// Files and directories that are exempt from the naming convention
+const ignoredFilesAndDirectories = [
+  'README.md',
+  'Dockerfile',
+  'LICENSE.md',
+  'customTypings',
+  'typings',
+];
+
+// Get the list of files that we're interested in validating
+const files = getFiles();
+
+// Create a place to store files in violation of naming convention
+const filesInViolation = [];
+
+// Now let's go through the files to see if they violate the naming convention
+files.forEach(file => {
+  // Split the path of the file to get the path components
+  const pathComponents = file.split('/');
+
+  // Let's start by assuming the file path has no invalid components
+  let fileIsValid = true;
+
+  // Let's process all path components to look for invalid ones
+  const processedPathComponents = pathComponents.map(pathComponents => {
+    if (!isCamelCase(pathComponents)) {
+      fileIsValid = false;
+
+      return red(pathComponents);
+    } else {
+      return pathComponents;
+    }
+  });
+
+  // If we encountered any invalid components for this file, we'll remember the file.
+  if (!fileIsValid) {
+    filesInViolation.push(processedPathComponents.join('/'));
+  }
+});
+
+// We're done looking through files.
+//
+// So, did we have any files in violation?
+if (filesInViolation.length > 0) {
+  // Yes, inform the user and exit with 1
+  console.log(
+    `\n${underscore('The file names below need to be camelCase:')}\n`,
+  );
+
+  filesInViolation.forEach(file => {
+    console.log(`• ${file}`);
+  });
+
+  shelljs.exit(1);
+} else {
+  // No, exit with 0
+  shelljs.exit(0);
+}
+
+function getFiles() {
+  // Let's only validate files managed by git
+  const files = shelljs.exec('git ls-files', { silent: true });
+
+  return files.split('\n').filter(file => {
+    return (
+      file.length !== 0 && !isIgnored(file) // remove empty strings from the array // remove files in ignored paths
+    );
+  });
+}
+function isCamelCase(filePathComponent) {
+  return camelCasedFileNameRegex.test(filePathComponent);
+}
+function isIgnored(filePath) {
+  const pathComponents = filePath.split('/');
+
+  // Check if there is an intersection between ignoredFilesAndDirectories and pathComponents
+  return ignoredFilesAndDirectories.some(ignoredFileOrDirectory => {
+    return pathComponents.some(pathComponent => {
+      return pathComponent === ignoredFileOrDirectory;
+    });
+  });
+}
+function red(text) {
+  return `\x1b[31m${text}\x1b[0m`;
+}
+function underscore(text) {
+  return `\x1b[4m${text}\x1b[0m`;
+}

--- a/validateFileNames.js
+++ b/validateFileNames.js
@@ -1,18 +1,25 @@
 const shelljs = require('shelljs');
 const minimatch = require('minimatch');
 const path = require('path')
+const fs = require('fs')
 
 // Regex that defines our file and directory naming convention
 const camelCasedFileNameRegex = /^[.]?([a-z])+([0-9]|[a-zA-Z]|[.])*$/;
 
 // Files and directories that are exempt from the naming convention
-const ignoredFilesAndDirectories = [
-  'README.md',
-  'Dockerfile',
-  'LICENSE.md',
-  'customTypings/*',
-  'typings/*',
-];
+let ignoredFilesAndDirectories = []
+
+try {
+  ignoredFilesAndDirectories = require(`${process.cwd()}/validateFileNames.js`);
+} catch (e) {
+  ignoredFilesAndDirectories = [
+    'README.md',
+    'Dockerfile',
+    'LICENSE.md',
+    'customTypings/*',
+    'typings/*',
+  ];
+}
 
 // Get the list of files that we're interested in validating
 const files = getFiles();


### PR DESCRIPTION
I wrote this script which will validate file and directory names according to our naming convention.

After we merge this, we will be able to run...

```
node ./node_modules/@hollowverse/common-config/validateFileNames.js
```

...from `hollowverse/hollowverse` and other repos...

The output looks like this

![](https://user-images.githubusercontent.com/26730388/29345263-6b3137c4-81f2-11e7-8196-f661df7c1f3c.png)

---

I tried to write this script in TypeScript and I was able to run it fine as...

```
./node_modules/.bin/ts-node validateFileNames.ts
```

...but when I moved it to `@hollowverse/common-config` and tried to run it...

```
./node_modules/.bin/ts-node ./node_modules/@hollowverse/common-config/validateFileNames.ts
```

...I kept getting all kinds of errors. I tried using the `-P` flag to set the right `tsconfig.json` and I tried to remove `node_modules` from the excluded paths in `tsconfig.json`, but no luck.

I'm okay with keeping this in JavaScript and relaxing our guidelines in the wiki a bit more if you're okay with this.

---

On an unrelated note: I changed the GitHub protected branch setting on this repo to not require a review before merging but still require a PR. So, we can send a PR and merge it immediately. That way we create visibility without causing workflow delays. And the option to request a review is still available, so we're good there as well.

I feel some repos, such as this one, might be better off using this workflow as opposed to requiring a review before merging.